### PR TITLE
fix: tests work if deadline is correct

### DIFF
--- a/tests/capstone.ts
+++ b/tests/capstone.ts
@@ -14,10 +14,10 @@ describe("capstone", () => {
 
   // https://www.unixtimestamp.com
   // Current unix timestamp in seconds
-  let currentTime = new BN(1726159390);
+  let currentTime = 1726221524;
   // +1 hour
-  let secondsFromNow = new BN(3600);
-  let deadline = currentTime + secondsFromNow;
+  let secondsFromNow = 3600;
+  let deadline = new BN(currentTime + secondsFromNow);
 
   let maker = new Keypair();
   // contributers
@@ -25,18 +25,21 @@ describe("capstone", () => {
   let c2 = new Keypair();
 
   // contributor amounts to donate
-  let c1Amt = BN(30);
-  let c2Amt = BN(20);
+  let c1Amt = new BN(30);
+  let c2Amt = new BN(20);
 
   let amount = new BN(LAMPORTS_PER_SOL).mul(new BN(20));
   let seed = new BN(randomBytes(16));
-  let fundraiser = PublicKey.findProgramAddressSync([Buffer.from("fundraiser"), maker.publicKey.toBuffer(), seed.toBuffer("le", 16)], program.programId)[0];
+  //let fundraiser = PublicKey.findProgramAddressSync([Buffer.from("fundraiser"), maker.publicKey.toBuffer(), seed.toBuffer("le", 16)], program.programId)[0];
+  let fundraiser = PublicKey.findProgramAddressSync([Buffer.from("fundraiser"), maker.publicKey.toBuffer()], program.programId)[0];
 
-  let c1Acct = PublicKey.findProgramAddressSync([Buffer.from("contributor"), fundraiser.publicKey.toBuffer(), c1.publicKey.toBuffer()], program.programId)[0];
-  let c2Acct = PublicKey.findProgramAddressSync([Buffer.from("contributor"), fundraiser.publicKey.toBuffer(), c2.publicKey.toBuffer()], program.programId)[0];
+  let c1Acct = PublicKey.findProgramAddressSync([Buffer.from("contributor"), fundraiser.toBuffer(), c1.publicKey.toBuffer()], program.programId)[0];
+  let c2Acct = PublicKey.findProgramAddressSync([Buffer.from("contributor"), fundraiser.toBuffer(), c2.publicKey.toBuffer()], program.programId)[0];
+
+  //let airdropAmt = new BN(100 * anchor.web3.LAMPORTS_PER_SOL);
 
   it("Airdrop", async () => {
-    await Promise.all([maker, donor1, donor2].map(async (k) => {
+    await Promise.all([maker, c1, c2].map(async (k) => {
       return await anchor.getProvider().connection.requestAirdrop(k.publicKey, 100 * anchor.web3.LAMPORTS_PER_SOL).then(confirmTx)
     }));
   });
@@ -45,10 +48,10 @@ describe("capstone", () => {
     // Add your test here.
     const tx = await program.methods
       .initialize(amount, deadline)
-      .accounts({
+      .accountsPartial({
         maker: maker.publicKey,
-        fundraiser,
-        systemProgram:SystemProgram.programId,
+        fundraiser: fundraiser,
+        systemProgram: SystemProgram.programId,
       })
       .signers([
         maker
@@ -62,14 +65,14 @@ describe("capstone", () => {
 
     const tx = await program.methods
       .contribute(c1Amt)
-      .accounts({
+      .accountsPartial({
         contributor: c1.publicKey,
-        fundraiser,
-        c1Acct,
+        fundraiser: fundraiser,
+        contributorAccount: c1Acct,
         systemProgram:SystemProgram.programId,
       })
       .signers([
-        maker
+        c1
       ]).rpc().then(confirmTx);
 
       console.log("Your transaction signature", tx);
@@ -80,14 +83,14 @@ describe("capstone", () => {
 
     const tx = await program.methods
       .contribute(c2Amt)
-      .accounts({
+      .accountsPartial({
         contributor: c2.publicKey,
-        fundraiser,
-        c2Acct,
+        fundraiser: fundraiser,
+        contributorAccount: c2Acct,
         systemProgram:SystemProgram.programId,
       })
       .signers([
-        maker
+        c2
       ]).rpc().then(confirmTx);
 
       console.log("Your transaction signature", tx);
@@ -97,10 +100,10 @@ describe("capstone", () => {
     // Add your test here.
 
     const tx = await program.methods
-      .check_contributions()
-      .accounts({
+      .checkContributions()
+      .accountsPartial({
         maker: maker.publicKey,
-        fundraiser,
+        fundraiser: fundraiser,
         systemProgram:SystemProgram.programId,
       })
       .signers([
@@ -115,15 +118,15 @@ describe("capstone", () => {
 
     const tx = await program.methods
       .refund()
-      .accounts({
+      .accountsPartial({
         contributor: c1.publicKey,
         maker: maker.publicKey,
-        fundraiser,
-        c1Acct,
+        fundraiser: fundraiser,
+        contributorAccount: c1Acct,
         systemProgram:SystemProgram.programId,
       })
       .signers([
-        maker
+        c1
       ]).rpc().then(confirmTx);
 
       console.log("Your transaction signature", tx);
@@ -134,15 +137,15 @@ describe("capstone", () => {
 
     const tx = await program.methods
       .refund()
-      .accounts({
+      .accountsPartial({
         contributor: c2.publicKey,
         maker: maker.publicKey,
-        fundraiser,
-        c2Acct,
+        fundraiser: fundraiser,
+        contributorAccount: c2Acct,
         systemProgram:SystemProgram.programId,
       })
       .signers([
-        maker
+        c2
       ]).rpc().then(confirmTx);
 
       console.log("Your transaction signature", tx);


### PR DESCRIPTION
Airdrops, initialize, and contributions work if deadline is in the future.
The final ones fail as expected because the deadline will not have been reached.
More fine-tuning is needed to reliably test the final tests once the deadline has been reached.